### PR TITLE
Small tweaks to call graph generation

### DIFF
--- a/index.php
+++ b/index.php
@@ -137,8 +137,9 @@ try {
 		case 'function_graph':
 			$dataFile = get('dataFile');
 			$showFraction = 100 - intval(get('showFraction') * 100);
-			if($showFraction < 0.5) {
-				$showFraction = 0.5;
+			$edgeArg = '';
+			if($showFraction < 0.1) {
+				$edgeArg = ' -e ' . $showFraction;
 			}
 			if($dataFile == '0'){
 				$files = Webgrind_FileHandler::getInstance()->getTraceList();
@@ -147,7 +148,7 @@ try {
             header("Content-Type: image/png");
             $filename = Webgrind_Config::storageDir().$dataFile.'-'.$showFraction.Webgrind_Config::$preprocessedSuffix.'.png';
 		    if (!file_exists($filename)) {
-				shell_exec(Webgrind_Config::$pythonExecutable.' library/gprof2dot.py -n '.$showFraction.' -f callgrind '.Webgrind_Config::xdebugOutputDir().''.$dataFile.' | '.Webgrind_Config::$dotExecutable.' -Tpng -o ' . $filename);
+				shell_exec(Webgrind_Config::$pythonExecutable.' library/gprof2dot.py -n '.$showFraction.$edgeArg.' -f callgrind '.Webgrind_Config::xdebugOutputDir().''.$dataFile.' | '.Webgrind_Config::$dotExecutable.' -Tpng -o ' . $filename);
 			}
 			readfile($filename);
 		break;


### PR DESCRIPTION
Just a couple of small changes to the call graph code to decrease memory usage (by using dot -o rather than reading the whole image into memory).

Also, it should now add a -e argument to gprof2dot equal to -n if -n is less than the -e default of 0.1 (which is pretty much only if someone chooses '100%' as the threshold in webgrind). This should eliminate a situation where dot generates an insanely wide graph because it culls the lines from the smallest calls so that they stack horizontally along the top.
