### PR TITLE
Changing call graph format from PNG to SVG

### DIFF
--- a/index.php
+++ b/index.php
@@ -145,10 +145,10 @@ try {
                 $files = Webgrind_FileHandler::getInstance()->getTraceList();
                 $dataFile = $files[0]['filename'];
             }
-            header("Content-Type: image/png");
-            $filename = Webgrind_Config::storageDir().$dataFile.'-'.$showFraction.Webgrind_Config::$preprocessedSuffix.'.png';
+            header("Content-Type: image/svg+xml");
+            $filename = Webgrind_Config::storageDir().$dataFile.'-'.$showFraction.Webgrind_Config::$preprocessedSuffix.'.svg';
 		    if (!file_exists($filename)) {
-				shell_exec(Webgrind_Config::$pythonExecutable.' library/gprof2dot.py -n '.$showFraction.' -f callgrind '.Webgrind_Config::xdebugOutputDir().''.$dataFile.' | '.Webgrind_Config::$dotExecutable.' -Tpng -o ' . $filename);
+				shell_exec(Webgrind_Config::$pythonExecutable.' library/gprof2dot.py -n '.$showFraction.' -f callgrind '.Webgrind_Config::xdebugOutputDir().''.$dataFile.' | '.Webgrind_Config::$dotExecutable.' -Tsvg -o ' . $filename);
 			}
 			readfile($filename);
 		break;


### PR DESCRIPTION
The PNG format did not scale well with very large
call graphs.  Once zoomed in on the PNG, the text
could not be read.  SVG solves this because it can
scale.