### PR TITLE
Support multiple {main} -- Show all functions -- Clear profiles button

### DIFF
--- a/index.php
+++ b/index.php
@@ -66,14 +66,14 @@ try {
                 }
 
             }
-            //usort($functions,'costCmp');
+            usort($functions,'costCmp');
 
             $result['functions'] = array();
             foreach($functions as $function){
                 $function['file'] = urlencode($function['file']);
                 $result['functions'][] = $function;
             }
-
+            
             $result['summedInvocationCount'] = $reader->getFunctionCount();
             $result['summedRunTime'] = $reader->formatCost($reader->getHeader('summary'), 'msec');
             $result['dataFile'] = $dataFile;
@@ -149,6 +149,20 @@ try {
         case 'version_info':
             $response = @file_get_contents('http://jokke.dk/webgrindupdate.json?version='.Webgrind_Config::$webgrindVersion);
             echo $response;
+        break;
+        case 'delete_profiles':
+            $fh = Webgrind_FileHandler::getInstance();
+
+            $deleted = array();
+            foreach ($fh->files as $f) {
+                $deleted[] = $f['absoluteFilename'];
+                unlink($f['absoluteFilename']);
+            }
+            echo json_encode(
+                array(
+                    'deleted' => $deleted
+                )
+            );
         break;
         default:
             $welcome = '';

--- a/index.php
+++ b/index.php
@@ -71,6 +71,8 @@ try {
             $result['functions'] = array();
             foreach($functions as $function){
                 $function['file'] = urlencode($function['file']);
+                $function['averageSelfCost'] = $function['summedSelfCostMSec'] / $function['invocationCount'];
+                $function['averageInclusiveCost'] = $function['summedInclusiveCostMSec'] / $function['invocationCount'];
                 $result['functions'][] = $function;
             }
             

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@ require './config.php';
 require './library/FileHandler.php';
 
 // TODO: Errorhandling:
-// 		No files, outputdir not writable
+//      No files, outputdir not writable
 
 set_time_limit(0);
 
@@ -39,7 +39,6 @@ try {
 
             for($i=0;$i<$reader->getFunctionCount();$i++) {
                 $functionInfo = $reader->getFunctionInfo($i);
-
 
                 if (false !== strpos($functionInfo['functionName'], 'php::')) {
                     $breakdown['internal'] += $functionInfo['summedSelfCost'];
@@ -67,19 +66,14 @@ try {
                 }
 
             }
-            usort($functions,'costCmp');
-
-            $remainingCost = $shownTotal*get('showFraction');
+            //usort($functions,'costCmp');
 
             $result['functions'] = array();
             foreach($functions as $function){
-
-                $remainingCost -= $function['summedSelfCost'];
                 $function['file'] = urlencode($function['file']);
                 $result['functions'][] = $function;
-                if($remainingCost<0)
-                    break;
             }
+
             $result['summedInvocationCount'] = $reader->getFunctionCount();
             $result['summedRunTime'] = $reader->formatCost($reader->getHeader('summary'), 'msec');
             $result['dataFile'] = $dataFile;
@@ -147,16 +141,16 @@ try {
             }
             header("Content-Type: image/png");
             $filename = Webgrind_Config::storageDir().$dataFile.'-'.$showFraction.Webgrind_Config::$preprocessedSuffix.'.png';
-		    if (!file_exists($filename)) {
-				shell_exec(Webgrind_Config::$pythonExecutable.' library/gprof2dot.py -n '.$showFraction.' -f callgrind '.Webgrind_Config::xdebugOutputDir().''.$dataFile.' | '.Webgrind_Config::$dotExecutable.' -Tpng -o ' . $filename);
-			}
-			readfile($filename);
-		break;
-    	case 'version_info':
-    		$response = @file_get_contents('http://jokke.dk/webgrindupdate.json?version='.Webgrind_Config::$webgrindVersion);
-    		echo $response;
-    	break;
-    	default:
+            if (!file_exists($filename)) {
+                shell_exec(Webgrind_Config::$pythonExecutable.' library/gprof2dot.py -n '.$showFraction.' -f callgrind '.Webgrind_Config::xdebugOutputDir().''.$dataFile.' | '.Webgrind_Config::$dotExecutable.' -Tpng -o ' . $filename);
+            }
+            readfile($filename);
+        break;
+        case 'version_info':
+            $response = @file_get_contents('http://jokke.dk/webgrindupdate.json?version='.Webgrind_Config::$webgrindVersion);
+            echo $response;
+        break;
+        default:
             $welcome = '';
             if (!file_exists(Webgrind_Config::storageDir()) || !is_writable(Webgrind_Config::storageDir())) {
                 $welcome .= 'Webgrind $storageDir does not exist or is not writeable: <code>'.Webgrind_Config::storageDir().'</code><br>';

--- a/library/Preprocessor.php
+++ b/library/Preprocessor.php
@@ -58,10 +58,21 @@ class Webgrind_Preprocessor
 		
 		
 		// Read information into memory
+		$entryCount = 0;
 		while(($line = fgets($in))){
 			if(substr($line,0,3)==='fl='){
 				// Found invocation of function. Read functionname
 				list($function) = fscanf($in,"fn=%[^\n\r]s");
+				// Special case for ENTRY_POINT - it contains summary header
+				if(self::ENTRY_POINT == $function){
+					fgets($in);				
+					$headers[] = fgets($in);
+					fgets($in);
+					if ($entryCount > 0) {
+						$function = $function . " ($entryCount)";
+					}
+					$entryCount++;
+				}
 				if(!isset($functions[$function])){
 					$functions[$function] = array(
                         'filename'              => substr(trim($line),3), 
@@ -75,12 +86,6 @@ class Webgrind_Preprocessor
 					);
 				} 
 				$functions[$function]['invocationCount']++;
-				// Special case for ENTRY_POINT - it contains summary header
-				if(self::ENTRY_POINT == $function){
-					fgets($in);				
-					$headers[] = fgets($in);
-					fgets($in);
-				}
 				// Cost line
 				list($lnr, $cost) = fscanf($in,"%d %d");
 				$functions[$function]['line'] = $lnr;

--- a/library/Reader.php
+++ b/library/Reader.php
@@ -32,6 +32,12 @@ class Webgrind_Reader
 	 * Length of a function information block
 	 */
 	const FUNCTIONINFORMATION_LENGTH = 6;	
+
+	const FORMAT_PERCENT = 'percent';
+
+	const FORMAT_MSEC = 'msec';
+
+	const FORMAT_USEC = 'usec';
 	
     /**
 	 * Address of the headers in the data file
@@ -123,9 +129,15 @@ class Webgrind_Reader
    		    'invocationCount'=>$invocationCount,
 			'calledFromInfoCount'=>$calledFromCount,
 			'subCallInfoCount'=>$subCallCount
-   		);            
+   		);
+   		
         $result['summedSelfCost'] = $this->formatCost($result['summedSelfCost']);
         $result['summedInclusiveCost'] = $this->formatCost($result['summedInclusiveCost']);
+
+        $result['summedSelfCostPercent'] = $this->formatCost($summedSelfCost, self::FORMAT_PERCENT);
+        $result['summedInclusiveCostPercent'] = $this->formatCost($summedInclusiveCost, self::FORMAT_PERCENT);
+        $result['summedSelfCostMSec'] = $this->formatCost($summedSelfCost, self::FORMAT_MSEC);
+        $result['summedInclusiveCostMSec'] = $this->formatCost($summedInclusiveCost, self::FORMAT_MSEC);
 
 		return $result;
 	}

--- a/styles/style.css
+++ b/styles/style.css
@@ -49,7 +49,6 @@ h2 {
 
 #options {
 	float:right;
-	width:720px;
 	padding:10px 0 0 0;
 }
 #options form {

--- a/styles/style.css
+++ b/styles/style.css
@@ -49,7 +49,7 @@ h2 {
 
 #options {
 	float:right;
-	width:580px;
+	width:720px;
 	padding:10px 0 0 0;
 }
 #options form {

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -66,7 +66,7 @@
                     $("#trace_view").show();
                     
                     $("#function_table").trigger('update');
-                    $("#function_table").trigger("sorton",[[[4,1]]]);
+                    $("#function_table").trigger("sorton",[[[5,1]]]);
                     
                     $('#callfilter').trigger('keyup');
                 }
@@ -229,6 +229,7 @@
                         <td> \
                             <img src="img/call_'+data.humanKind+'.png" title="'+data.humanKind+'"> \
                         </td> \
+                        <td class="nr">'+data.nr+'</td> \
                         <td> \
                             <a href="javascript:toggleCallInfo('+data.nr+')"> \
                                 <img id="fold_marker_'+data.nr+'" src="img/right.gif">&nbsp;&nbsp;'+data.functionName+' \
@@ -237,8 +238,12 @@
                         </td> \
                         <td>'+openLink+'</td> \
                         <td class="nr">'+data.invocationCount+'</td> \
-                        <td class="nr">'+data.summedSelfCost+'</td> \
-                        <td class="nr">'+data.summedInclusiveCost+'</td> \
+                        <td class="nr">'+data.averageSelfCost.toFixed(2)+'ms</td> \
+                        <td class="nr">'+data.averageInclusiveCost.toFixed(2)+'ms</td> \
+                        <td class="nr">'+data.summedSelfCostPercent+'%</td> \
+                        <td class="nr">'+data.summedInclusiveCostPercent+'%</td> \
+                        <td class="nr">'+data.summedSelfCostMSec+'ms</td> \
+                        <td class="nr">'+data.summedInclusiveCostMSec+'ms</td> \
                     </tr> \
             ';
         }
@@ -268,6 +273,17 @@
             );          
             
         }
+
+        $.tablesorter.addParser({
+            id : 'ms',
+            is : function(s) {
+                return false;
+            },
+            format: function(s) {
+                return parseFloat(s.toLowerCase().replace(/ms$/,''));
+            },
+            type: 'numeric'
+        });
         
         $(document).ready(function() { 
             
@@ -280,12 +296,16 @@
                 widgets: ['zebra'],
                 sortInitialOrder: 'desc',
                 headers: { 
-                    1: { 
-                        sorter: false 
-                    },
-                    2: {
-                        sorter: false
-                    }
+                    3:{sorter: false},
+                    5:{sorter:'ms'},
+                    6:{sorter:'ms'},
+                    7:{sorter:'percent'},
+                    8:{sorter:'percent'},
+                    8:{sorter:'ms'},
+                    10:{sorter:'ms'}
+                },
+                textExtraction : function(node) {
+                    return $.trim($(node).text());
                 }
             });
             $("#function_table").bind("sortStart",sortBlock).bind("sortEnd",$.unblockUI);
@@ -321,19 +341,15 @@
         </div>
         <div id="options">
             <form method="get" onsubmit="update();return false;">
-                <div style="float:right;margin-left:10px">
-                    <input type="submit" value="update"/>
-                    <input type="button" onclick="deleteProfiles();return false;" value="clear profiles"/>
-                </div>
-                <div style="float:right;">
-                    <label style="margin:0 5px">in</label>
-                    <select id="costFormat" name="costFormat">
-                        <option value="percent" <?php echo (Webgrind_Config::$defaultCostformat=='percent') ? 'selected' : ''?>>percent</option>
-                        <option value="msec" <?php echo (Webgrind_Config::$defaultCostformat=='msec') ? 'selected' : ''?>>milliseconds</option>
-                        <option value="usec" <?php echo (Webgrind_Config::$defaultCostformat=='usec') ? 'selected' : ''?>>microseconds</option>
+                <div style="float:left">
+                    <label style="margin:0 5px">Show</label>
+                    <select id="showFraction" name="showFraction">
+                        <?php for($i=100; $i>0; $i-=10):?>
+                        <option value="<?php echo $i/100?>" <?php if ($i==Webgrind_Config::$defaultFunctionPercentage):?>selected="selected"<?php endif;?>><?php echo $i?>%</option>
+                        <?php endfor;?>
                     </select>
                 </div>
-                <div style="float:right;">
+                <div style="float:left;">
                     <label style="margin:0 5px">of</label>
                     <select id="dataFile" name="dataFile" style="width:200px">
                         <option value="0">Auto (newest)</option>
@@ -342,18 +358,14 @@
                             <option value="<?php echo $trace['filename']?>"><?php echo str_replace(array('%i','%f','%s','%m'),array($trace['invokeUrl'],$trace['filename'],$trace['filesize'],$trace['mtime']),Webgrind_Config::$traceFileListFormat); ?></option>
                         <?php endforeach;?>
                     </select>
-                    <img class="list_reload" src="img/reload.png" onclick="reloadFilelist()">
+                    <img class="list_reload" src="img/reload.png" title="Reload File List" onclick="reloadFilelist()">
                 </div>
-                <div style="float:right">
-                    <label style="margin:0 5px">Show</label>
-                    <select id="showFraction" name="showFraction">
-                        <?php for($i=100; $i>0; $i-=10):?>
-                        <option value="<?php echo $i/100?>" <?php if ($i==Webgrind_Config::$defaultFunctionPercentage):?>selected="selected"<?php endif;?>><?php echo $i?>%</option>
-                        <?php endfor;?>
-                    </select>
+                <div style="float:left;margin-left:10px">
+                    <input type="submit" value="update"/>
+                    <input type="button" onclick="deleteProfiles();return false;" value="clear profiles"/>
                 </div>
                 <div style="clear:both;"></div>     
-                <div style="margin:0 70px">
+                <div style="">
                     <input type="checkbox" name="hideInternals" value="1" <?php echo (Webgrind_Config::$defaultHideInternalFunctions==1) ? 'checked' : ''?> id="hideInternals">
                     <label for="hideInternals">Hide PHP functions</label>
                 </div>
@@ -379,12 +391,17 @@
             <table class="tablesorter" id="function_table" cellspacing="0">
                 <thead>
                     <tr>
-                        <th> </th>
-                        <th><span>Function</span></th>
-                        <th> </th>
-                        <th><span>Invocation Count</span></th>
-                        <th><span>Total Self Cost</span></th>
-                        <th><span>Total Inclusive Cost</span></th>
+                        <th title="Type of function"> </th>
+                        <th title="Function Order"> </th>
+                        <th title="Function Name"><span>Function</span></th>
+                        <th title="View Source"> </th>
+                        <th title="Number of times the function was called"><span>Invocation Count</span></th>
+                        <th title="Average time running function (not including subcalls)"><span>Avg. Self Cost</span></th>
+                        <th title="Average time running function and all children functions"><span>Avg. Inclusive Cost</span></th>
+                        <th title="Total percentage of time spent running this function"><span>Total Self Cost (%)</span></th>
+                        <th title="Total percentage of time spent running this and children functions"><span>Total Inclusive Cost (%)</span></th>
+                        <th title="Total time spent running this function"><span>Total Self Cost (ms)</span></th>
+                        <th title="Total time spent running this and children functions"><span>Total Inclusive Cost (ms)</span></th>
                     </tr>
                 </thead>
                 <tbody>

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -301,7 +301,7 @@
                     6:{sorter:'ms'},
                     7:{sorter:'percent'},
                     8:{sorter:'percent'},
-                    8:{sorter:'ms'},
+                    9:{sorter:'ms'},
                     10:{sorter:'ms'}
                 },
                 textExtraction : function(node) {

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -18,7 +18,7 @@
         function getOptions(specificFile){
             var options = new Object();
             options.dataFile = specificFile || $("#dataFile").val();
-            options.costFormat = $('#costFormat').val();
+            options.costFormat = $('[name="costFormat"]').val();
             options.showFraction = $("#showFraction").val();
             options.hideInternals = $('#hideInternals').attr('checked') ? 1 : 0;
             return options;
@@ -128,7 +128,7 @@
         
         function loadCallInfo(functionNr){          
             $.getJSON("index.php",
-                {'op':'callinfo_list', 'file':currentDataFile, 'functionNr':functionNr, 'costFormat':$("#costFormat").val()},
+                {'op':'callinfo_list', 'file':currentDataFile, 'functionNr':functionNr, 'costFormat':$("[name='costFormat']").val()},
                 function(data){
                     if (data.error) {
                         $("#hello_message").html(data.error);
@@ -188,7 +188,7 @@
                         +($("#callinfo_area_"+data.functionNr).length ? '<img src="img/right.gif">&nbsp;&nbsp;<a href="javascript:openCallInfo('+data.functionNr+')">'+data.callerFunctionName+'</a>' : '<img src="img/blank.gif">&nbsp;&nbsp;'+data.callerFunctionName)
                         + ' @ '+data.line+'</td> \
                         <td class="nr">'+data.callCount+'</td> \
-                        <td class="nr">'+data.summedCallCost+'</td> \
+                        <td class="nr">'+data.summedCallCost+'ms</td> \
                         <td><a title="Open file and show line" href="'+sprintf(fileUrlFormat,data.file,data.line)+'" target="_blank"><img src="img/file_line.png" alt="O"></a></td> \
                     </tr>';
             
@@ -342,6 +342,7 @@
         </div>
         <div id="options">
             <form method="get" onsubmit="update();return false;">
+                <input type="hidden" name="costFormat" value="msec" />
                 <div style="float:left">
                     <label style="margin:0 5px">Show</label>
                     <select id="showFraction" name="showFraction">

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -81,6 +81,7 @@
 
             var data = {};
             data.op = 'delete_profiles';
+            $("#trace_view").hide();
             $("#hello_message").html('Deleting your saved profiles').show();
             $.getJSON("index.php",
                 data,

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -323,7 +323,7 @@
                 var row;
                 $('#function_table').children('tbody').children('tr').each(function(){
                     row = $(this);
-                    if (row.find('td:eq(1) a').text().match(reg))
+                    if (row.find('td:eq(2) a').text().match(reg))
                         row.css('display', 'table-row');
                     else
                         row.css('display', 'none');

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -320,10 +320,11 @@
             
             $("#callfilter").keyup(function(){
                 var reg = new RegExp($(this).val(), 'i');
-                var row;
+                var row, text;
                 $('#function_table').children('tbody').children('tr').each(function(){
                     row = $(this);
-                    if (row.find('td:eq(2) a').text().match(reg))
+                    text = $.trim(row.find('td:eq(2) a').text());
+                    if (text.match(reg))
                         row.css('display', 'table-row');
                     else
                         row.css('display', 'none');
@@ -387,7 +388,7 @@
                 <div><input type="button" name="graph" value="Show Call Graph" onclick="showCallGraph()"></div>
             </div>
             <div style="clear:both"></div>
-            Filter: <input type="text" style="width:150px" id="callfilter"> (regex too)
+            Filter: <input type="text" style="width:150px" id="callfilter"> (regex too) You can filter out php, include, and requires with <b>^[^php::|include::|include_once::|require::|require_once::]</b>
             <table class="tablesorter" id="function_table" cellspacing="0">
                 <thead>
                     <tr>

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -162,9 +162,8 @@
             $("#"+idPrefix+functionNr).tablesorter({
                 widgets: ['zebra'],
                 headers: { 
-                    3: { 
-                        sorter: false 
-                    }
+                    2: {sorter: 'ms'},
+                    3: {sorter: false}
                 }                           
             });
             $("#"+idPrefix+functionNr).bind("sortStart",sortBlock).bind("sortEnd",$.unblockUI);

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -1,57 +1,57 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+    "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-	<meta http-equiv="Content-type" content="text/html; charset=utf-8">
-	<title>webgrind</title>
-	<link rel="stylesheet" type="text/css" href="styles/style.css">
-	<script src="js/jquery.js" type="text/javascript" charset="utf-8"></script>
-	<script src="js/jquery.blockUI.js" type="text/javascript" charset="utf-8"></script>
-	<script src="js/jquery.tablesorter.js" type="text/javascript" charset="utf-8"></script>
-	<script src="js/jquery.selectboxes.js" type="text/javascript" charset="utf-8"></script>
-	<script src="js/sprintf.js" type="text/javascript" charset="utf-8"></script>
-	<script type="text/javascript" charset="utf-8">
-		var fileUrlFormat = '<?php echo Webgrind_Config::$fileUrlFormat?>';
-		var currentDataFile = null;
-		var callInfoLoaded = new Array();
-		var disableAjaxBlock = false;
-		function getOptions(specificFile){
-			var options = new Object();
-			options.dataFile = specificFile || $("#dataFile").val();
-			options.costFormat = $('#costFormat').val();
-			options.showFraction = $("#showFraction").val();
-			options.hideInternals = $('#hideInternals').attr('checked') ? 1 : 0;
-			return options;
-		}
-		
-		function update(specificFile){
-			vars = getOptions(specificFile);
-			vars.op = 'function_list';
-			$.getJSON("index.php",
-				vars,
-				function(data){
-				    if (data.error) {
-				        $("#hello_message").html(data.error);
-				        $("#hello_message").show();
-				        return;
-				    }
-					callInfoLoaded = new Array();
-					$("#function_table tbody").empty();
-					for(i=0;i<data.functions.length;i++){
-						callInfoLoaded[data.functions[i].nr] = false;
-						$("#function_table tbody").append(functionTableRow(data.functions[i], data.linkToFunctionLine));
-					}
-					currentDataFile = data.dataFile;
-					$("#data_file").html(data.dataFile);
-					$("#invoke_url").html(data.invokeUrl);
-					$(document).attr('title', 'webgrind of '+data.invokeUrl);
-					$("#mtime").html(data.mtime);
-					$("#shown_sum").html(data.functions.length);
-					$("#invocation_sum").html(data.summedInvocationCount);
-					$("#runtime_sum").html(data.summedRunTime);
-					$("#runs").html(data.runs);
-					
-					var breakdown_sum = data.breakdown['internal']+data.breakdown['procedural']+data.breakdown['class']+data.breakdown['include'];
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <title>webgrind</title>
+    <link rel="stylesheet" type="text/css" href="styles/style.css">
+    <script src="js/jquery.js" type="text/javascript" charset="utf-8"></script>
+    <script src="js/jquery.blockUI.js" type="text/javascript" charset="utf-8"></script>
+    <script src="js/jquery.tablesorter.js" type="text/javascript" charset="utf-8"></script>
+    <script src="js/jquery.selectboxes.js" type="text/javascript" charset="utf-8"></script>
+    <script src="js/sprintf.js" type="text/javascript" charset="utf-8"></script>
+    <script type="text/javascript" charset="utf-8">
+        var fileUrlFormat = '<?php echo Webgrind_Config::$fileUrlFormat?>';
+        var currentDataFile = null;
+        var callInfoLoaded = new Array();
+        var disableAjaxBlock = false;
+        function getOptions(specificFile){
+            var options = new Object();
+            options.dataFile = specificFile || $("#dataFile").val();
+            options.costFormat = $('#costFormat').val();
+            options.showFraction = $("#showFraction").val();
+            options.hideInternals = $('#hideInternals').attr('checked') ? 1 : 0;
+            return options;
+        }
+        
+        function update(specificFile){
+            vars = getOptions(specificFile);
+            vars.op = 'function_list';
+            $.getJSON("index.php",
+                vars,
+                function(data){
+                    if (data.error) {
+                        $("#hello_message").html(data.error);
+                        $("#hello_message").show();
+                        return;
+                    }
+                    callInfoLoaded = new Array();
+                    $("#function_table tbody").empty();
+                    for(i=0;i<data.functions.length;i++){
+                        callInfoLoaded[data.functions[i].nr] = false;
+                        $("#function_table tbody").append(functionTableRow(data.functions[i], data.linkToFunctionLine));
+                    }
+                    currentDataFile = data.dataFile;
+                    $("#data_file").html(data.dataFile);
+                    $("#invoke_url").html(data.invokeUrl);
+                    $(document).attr('title', 'webgrind of '+data.invokeUrl);
+                    $("#mtime").html(data.mtime);
+                    $("#shown_sum").html(data.functions.length);
+                    $("#invocation_sum").html(data.summedInvocationCount);
+                    $("#runtime_sum").html(data.summedRunTime);
+                    $("#runs").html(data.runs);
+                    
+                    var breakdown_sum = data.breakdown['internal']+data.breakdown['procedural']+data.breakdown['class']+data.breakdown['include'];
                     $("#breakdown").html(
                         '<img src="img/gradient_left.png" height="20" width="10">'+
                         '<img src="img/gradient_internal.png" height="20" width="'+Math.floor(data.breakdown['internal']/breakdown_sum*300)+'">'+
@@ -61,227 +61,256 @@
                         '<img src="img/gradient_right.png" height="20" width="10">'+
                         '<div title="internal functions, include/require, class methods and procedural functions." style="position:relative;top:-20px;left:10px;width:301px;height:19px"></div>'
                     );
-					
-					$("#hello_message").hide();
-					$("#trace_view").show();
-					
-					$("#function_table").trigger('update');
-					$("#function_table").trigger("sorton",[[[4,1]]]);
-					
-					$('#callfilter').trigger('keyup');
-				}
-			);
-		}
+                    
+                    $("#hello_message").hide();
+                    $("#trace_view").show();
+                    
+                    $("#function_table").trigger('update');
+                    $("#function_table").trigger("sorton",[[[4,1]]]);
+                    
+                    $('#callfilter').trigger('keyup');
+                }
+            );
+        }
 
-		function showCallGraph() {
-			vars = getOptions();
-			vars.op = 'function_graph';
-			delete vars.costFormat;
-			delete vars.hideInternals;
-			window.open('index.php?' + $.param(vars));
-		}
-		
-		function reloadFilelist(){
-			$.getJSON("index.php",
-				{'op':'file_list'},
-				function(data){
-					var options = new Object();
-					for(i=0;i<data.length;i++){
-						options[data[i]['filename']] = data[i]['invokeUrl']+' ('+data[i]['filename']+')'+' ['+data[i]['filesize']+']';
-					}
-					$("#dataFile").removeOption(/[^0]/);
-					$("#dataFile").addOption(options, false);
+        function deleteProfiles() {
+            var confirm = window.confirm('Are you sure? This will delete all of the profiling data you have collected.');
+            if (!confirm) {
+                return false;
+            }
 
-				}
-			);
-		}
-		
-		function loadCallInfo(functionNr){			
-			$.getJSON("index.php",
-				{'op':'callinfo_list', 'file':currentDataFile, 'functionNr':functionNr, 'costFormat':$("#costFormat").val()},
-				function(data){
-					if (data.error) {
-				        $("#hello_message").html(data.error);
-				        $("#hello_message").show();
-				        return;
-				    }
-				    
-					if(data.calledByHost)
-						$("#callinfo_area_"+functionNr).append('<b>Called from script host</b>');
-					
-					insertCallInfo(functionNr, 'sub_calls_table_', 'Calls', data.subCalls);
-					insertCallInfo(functionNr, 'called_from_table_', 'Called From', data.calledFrom);
+            var data = {};
+            data.op = 'delete_profiles';
+            $("#hello_message").html('Deleting your saved profiles').show();
+            $.getJSON("index.php",
+                data,
+                function(data){
+                    if (data.deleted) {
+                        if (data.deleted.length) {
+                            files = data.deleted.join('</li><li>');
+                            $("#hello_message")
+                                .html('Deleted the following profiles:<ul><li>' + files + '</li></ul>')
+                                .show();
+                        } else {
+                            $("#hello_message").html('Found no profiles to delete.').show();
+                        }
+                    } else {
+                        $("#hello_message").html('Could not delete the saved profiles.').show();
+                    }
+                    
+                }
+            );
+        }
 
-					
-					callInfoLoaded[functionNr] = true;
-				}
-			);				
-		
-		}
-		
-		function insertCallInfo(functionNr, idPrefix, title, data){
-			if(data.length==0)
-				return;
-				
-			$("#callinfo_area_"+functionNr).append(callTable(functionNr,idPrefix, title));
-			
-			for(i=0;i<data.length;i++){
-				$("#"+idPrefix+functionNr+" tbody").append(callTableRow(i, data[i]));
-			}
-			
-			$("#"+idPrefix+functionNr).tablesorter({
-				widgets: ['zebra'],
-				headers: { 
-		            3: { 
-		                sorter: false 
-		            }
-		        }							
-			});
-			$("#"+idPrefix+functionNr).bind("sortStart",sortBlock).bind("sortEnd",$.unblockUI);
-			$("#"+idPrefix+functionNr).trigger("sorton",[[[2,1]]]); 				
-				
-			
-		}
-		
-		function callTable(functionNr, idPrefix, title){
-			return '<table class="tablesorter" id="'+idPrefix+functionNr+'" cellspacing="0"> \
-						<thead><tr><th><span>'+title+'</span></th><th><span>Count</span></th><th><span>Total Call Cost</span></th><th> </th></tr></thead> \
-						<tbody> \
-						</tbody> \
-					</table> \
-			';
-		}
-		
-		function callTableRow(nr,data){
-			return '<tr> \
-						<td>'
-						+($("#callinfo_area_"+data.functionNr).length ? '<img src="img/right.gif">&nbsp;&nbsp;<a href="javascript:openCallInfo('+data.functionNr+')">'+data.callerFunctionName+'</a>' : '<img src="img/blank.gif">&nbsp;&nbsp;'+data.callerFunctionName)
-						+ ' @ '+data.line+'</td> \
-						<td class="nr">'+data.callCount+'</td> \
-						<td class="nr">'+data.summedCallCost+'</td> \
-						<td><a title="Open file and show line" href="'+sprintf(fileUrlFormat,data.file,data.line)+'" target="_blank"><img src="img/file_line.png" alt="O"></a></td> \
-					</tr>';
-			
-		}
-				
-		function toggleCallInfo(functionNr){
-			if(!callInfoLoaded[functionNr]){
-				loadCallInfo(functionNr);
-			}					
-			
-			$("#callinfo_area_"+functionNr).toggle();
-			current = $("#fold_marker_"+functionNr).get(0).src;
-			if(current.substr(current.lastIndexOf('/')+1) == 'right.gif')
-				$("#fold_marker_"+functionNr).get(0).src = 'img/down.gif';
-			else
-				$("#fold_marker_"+functionNr).get(0).src = 'img/right.gif';
-		}
-		
-		function openCallInfo(functionNr) {
-			var areaEl = $("#callinfo_area_"+functionNr);
-			if (areaEl.length) {
-    			if (areaEl.is(":hidden")) toggleCallInfo(functionNr);
-    			window.scrollTo(0, areaEl.parent().offset().top);
-    		}
-		}
-		
-		function functionTableRow(data, linkToFunctionLine){
-			if (data.file=='php%3Ainternal') {
-			    openLink = '<a title="Lookup function" href="<?php echo ini_get('xdebug.manual_url')?>/'+data.functionName.substr(5)+'" target="_blank"><img src="img/file.png" alt="O"></a>';;
-			} else {
-			    if(linkToFunctionLine){
-			        openLink = '<a title="Open file and show line" href="'+sprintf(fileUrlFormat, data.file, data.line)+'" target="_blank"><img src="img/file_line.png" alt="O"></a>';
-		        } else {
-		            openLink = '<a title="Open file" href="'+sprintf(fileUrlFormat, data.file, -1)+'" target="_blank"><img src="img/file.png" alt="O"></a>';
-		        }
-			}
-			return '<tr> \
-			            <td> \
-			                <img src="img/call_'+data.humanKind+'.png" title="'+data.humanKind+'"> \
-			            </td> \
-						<td> \
-							<a href="javascript:toggleCallInfo('+data.nr+')"> \
-								<img id="fold_marker_'+data.nr+'" src="img/right.gif">&nbsp;&nbsp;'+data.functionName+' \
-							</a> \
-							<div class="callinfo_area" id="callinfo_area_'+data.nr+'"></div> \
-						</td> \
-						<td>'+openLink+'</td> \
-						<td class="nr">'+data.invocationCount+'</td> \
-						<td class="nr">'+data.summedSelfCost+'</td> \
-						<td class="nr">'+data.summedInclusiveCost+'</td> \
-					</tr> \
-			';
-		}
-		
-		function sortBlock(){
-			$.blockUI('<div class="block_box"><h1>Sorting...</h1></div>');
-		}
-		
-		function loadBlock(){
-			if(!disableAjaxBlock)
-				$.blockUI();
-			disableAjaxBlock = false;
-		}
-		
-		function checkVersion(){
-			disableAjaxBlock = true;
-			$.getJSON("index.php",
-				{'op':'version_info'},
-				function(data){
-					if(data.latest_version><?php echo Webgrind_Config::$webgrindVersion?>){
-						$("#version_info").append('Version '+data.latest_version+' is available for <a href="'+data.download_url+'">download</a>.');
-					} else {
-						$("#version_info").append('You have the latest version.');
-					}
+        function showCallGraph() {
+            vars = getOptions();
+            vars.op = 'function_graph';
+            delete vars.costFormat;
+            delete vars.hideInternals;
+            window.open('index.php?' + $.param(vars));
+        }
+        
+        function reloadFilelist(){
+            $.getJSON("index.php",
+                {'op':'file_list'},
+                function(data){
+                    var options = new Object();
+                    for(i=0;i<data.length;i++){
+                        options[data[i]['filename']] = data[i]['invokeUrl']+' ('+data[i]['filename']+')'+' ['+data[i]['filesize']+']';
+                    }
+                    $("#dataFile").removeOption(/[^0]/);
+                    $("#dataFile").addOption(options, false);
 
-				}
-			);			
-			
-		}
-		
-		$(document).ready(function() { 
-			
-			$.blockUI.defaults.pageMessage = '<div class="block_box"><h1>Loading...</h1><p>Loading information from server. If the callgrind file is large this may take some time.</p></div>';
-			$.blockUI.defaults.overlayCSS =  { backgroundColor: '#fff', opacity: '0' }; 
-			$.blockUI.defaults.fadeIn = 0;
-			$.blockUI.defaults.fadeOut = 0;
-			$().ajaxStart(loadBlock).ajaxStop($.unblockUI);
-			$("#function_table").tablesorter({
-				widgets: ['zebra'],
-				sortInitialOrder: 'desc',
-				headers: { 
-		            1: { 
-		                sorter: false 
-		            },
-		            2: {
-		                sorter: false
-		            }
-		        }
-			});
-			$("#function_table").bind("sortStart",sortBlock).bind("sortEnd",$.unblockUI);
-			
-			if(document.location.hash) {
-				update(document.location.hash.substr(1));
-			}
-			
-			<?php if(Webgrind_Config::$checkVersion):?>
-			setTimeout(checkVersion,100);
-			<?php endif?>
-			
-			$("#callfilter").keyup(function(){
-			    var reg = new RegExp($(this).val(), 'i');
-			    var row;
-			    $('#function_table').children('tbody').children('tr').each(function(){
-			        row = $(this);
-			        if (row.find('td:eq(1) a').text().match(reg))
-			            row.css('display', 'table-row');
-			        else
-			            row.css('display', 'none');
-			    });
-    		});
-		});
-		
-	</script>
+                }
+            );
+        }
+        
+        function loadCallInfo(functionNr){          
+            $.getJSON("index.php",
+                {'op':'callinfo_list', 'file':currentDataFile, 'functionNr':functionNr, 'costFormat':$("#costFormat").val()},
+                function(data){
+                    if (data.error) {
+                        $("#hello_message").html(data.error);
+                        $("#hello_message").show();
+                        return;
+                    }
+                    
+                    if(data.calledByHost)
+                        $("#callinfo_area_"+functionNr).append('<b>Called from script host</b>');
+                    
+                    insertCallInfo(functionNr, 'sub_calls_table_', 'Calls', data.subCalls);
+                    insertCallInfo(functionNr, 'called_from_table_', 'Called From', data.calledFrom);
+
+                    
+                    callInfoLoaded[functionNr] = true;
+                }
+            );              
+        
+        }
+        
+        function insertCallInfo(functionNr, idPrefix, title, data){
+            if(data.length==0)
+                return;
+                
+            $("#callinfo_area_"+functionNr).append(callTable(functionNr,idPrefix, title));
+            
+            for(i=0;i<data.length;i++){
+                $("#"+idPrefix+functionNr+" tbody").append(callTableRow(i, data[i]));
+            }
+            
+            $("#"+idPrefix+functionNr).tablesorter({
+                widgets: ['zebra'],
+                headers: { 
+                    3: { 
+                        sorter: false 
+                    }
+                }                           
+            });
+            $("#"+idPrefix+functionNr).bind("sortStart",sortBlock).bind("sortEnd",$.unblockUI);
+            $("#"+idPrefix+functionNr).trigger("sorton",[[[2,1]]]);                 
+                
+            
+        }
+        
+        function callTable(functionNr, idPrefix, title){
+            return '<table class="tablesorter" id="'+idPrefix+functionNr+'" cellspacing="0"> \
+                        <thead><tr><th><span>'+title+'</span></th><th><span>Count</span></th><th><span>Total Call Cost</span></th><th> </th></tr></thead> \
+                        <tbody> \
+                        </tbody> \
+                    </table> \
+            ';
+        }
+        
+        function callTableRow(nr,data){
+            return '<tr> \
+                        <td>'
+                        +($("#callinfo_area_"+data.functionNr).length ? '<img src="img/right.gif">&nbsp;&nbsp;<a href="javascript:openCallInfo('+data.functionNr+')">'+data.callerFunctionName+'</a>' : '<img src="img/blank.gif">&nbsp;&nbsp;'+data.callerFunctionName)
+                        + ' @ '+data.line+'</td> \
+                        <td class="nr">'+data.callCount+'</td> \
+                        <td class="nr">'+data.summedCallCost+'</td> \
+                        <td><a title="Open file and show line" href="'+sprintf(fileUrlFormat,data.file,data.line)+'" target="_blank"><img src="img/file_line.png" alt="O"></a></td> \
+                    </tr>';
+            
+        }
+                
+        function toggleCallInfo(functionNr){
+            if(!callInfoLoaded[functionNr]){
+                loadCallInfo(functionNr);
+            }                   
+            
+            $("#callinfo_area_"+functionNr).toggle();
+            current = $("#fold_marker_"+functionNr).get(0).src;
+            if(current.substr(current.lastIndexOf('/')+1) == 'right.gif')
+                $("#fold_marker_"+functionNr).get(0).src = 'img/down.gif';
+            else
+                $("#fold_marker_"+functionNr).get(0).src = 'img/right.gif';
+        }
+        
+        function openCallInfo(functionNr) {
+            var areaEl = $("#callinfo_area_"+functionNr);
+            if (areaEl.length) {
+                if (areaEl.is(":hidden")) toggleCallInfo(functionNr);
+                window.scrollTo(0, areaEl.parent().offset().top);
+            }
+        }
+        
+        function functionTableRow(data, linkToFunctionLine){
+            if (data.file=='php%3Ainternal') {
+                openLink = '<a title="Lookup function" href="<?php echo ini_get('xdebug.manual_url')?>/'+data.functionName.substr(5)+'" target="_blank"><img src="img/file.png" alt="O"></a>';;
+            } else {
+                if(linkToFunctionLine){
+                    openLink = '<a title="Open file and show line" href="'+sprintf(fileUrlFormat, data.file, data.line)+'" target="_blank"><img src="img/file_line.png" alt="O"></a>';
+                } else {
+                    openLink = '<a title="Open file" href="'+sprintf(fileUrlFormat, data.file, -1)+'" target="_blank"><img src="img/file.png" alt="O"></a>';
+                }
+            }
+            return '<tr> \
+                        <td> \
+                            <img src="img/call_'+data.humanKind+'.png" title="'+data.humanKind+'"> \
+                        </td> \
+                        <td> \
+                            <a href="javascript:toggleCallInfo('+data.nr+')"> \
+                                <img id="fold_marker_'+data.nr+'" src="img/right.gif">&nbsp;&nbsp;'+data.functionName+' \
+                            </a> \
+                            <div class="callinfo_area" id="callinfo_area_'+data.nr+'"></div> \
+                        </td> \
+                        <td>'+openLink+'</td> \
+                        <td class="nr">'+data.invocationCount+'</td> \
+                        <td class="nr">'+data.summedSelfCost+'</td> \
+                        <td class="nr">'+data.summedInclusiveCost+'</td> \
+                    </tr> \
+            ';
+        }
+        
+        function sortBlock(){
+            $.blockUI('<div class="block_box"><h1>Sorting...</h1></div>');
+        }
+        
+        function loadBlock(){
+            if(!disableAjaxBlock)
+                $.blockUI();
+            disableAjaxBlock = false;
+        }
+        
+        function checkVersion(){
+            disableAjaxBlock = true;
+            $.getJSON("index.php",
+                {'op':'version_info'},
+                function(data){
+                    if(data.latest_version><?php echo Webgrind_Config::$webgrindVersion?>){
+                        $("#version_info").append('Version '+data.latest_version+' is available for <a href="'+data.download_url+'">download</a>.');
+                    } else {
+                        $("#version_info").append('You have the latest version.');
+                    }
+
+                }
+            );          
+            
+        }
+        
+        $(document).ready(function() { 
+            
+            $.blockUI.defaults.pageMessage = '<div class="block_box"><h1>Loading...</h1><p>Loading information from server. If the callgrind file is large this may take some time.</p></div>';
+            $.blockUI.defaults.overlayCSS =  { backgroundColor: '#fff', opacity: '0' }; 
+            $.blockUI.defaults.fadeIn = 0;
+            $.blockUI.defaults.fadeOut = 0;
+            $().ajaxStart(loadBlock).ajaxStop($.unblockUI);
+            $("#function_table").tablesorter({
+                widgets: ['zebra'],
+                sortInitialOrder: 'desc',
+                headers: { 
+                    1: { 
+                        sorter: false 
+                    },
+                    2: {
+                        sorter: false
+                    }
+                }
+            });
+            $("#function_table").bind("sortStart",sortBlock).bind("sortEnd",$.unblockUI);
+            
+            if(document.location.hash) {
+                update(document.location.hash.substr(1));
+            }
+            
+            <?php if(Webgrind_Config::$checkVersion):?>
+            setTimeout(checkVersion,100);
+            <?php endif?>
+            
+            $("#callfilter").keyup(function(){
+                var reg = new RegExp($(this).val(), 'i');
+                var row;
+                $('#function_table').children('tbody').children('tr').each(function(){
+                    row = $(this);
+                    if (row.find('td:eq(1) a').text().match(reg))
+                        row.css('display', 'table-row');
+                    else
+                        row.css('display', 'none');
+                });
+            });
+        });
+        
+    </script>
 </head>
 <body>
     <div id="head">
@@ -291,41 +320,42 @@
         </div>
         <div id="options">
             <form method="get" onsubmit="update();return false;">
-            	<div style="float:right;margin-left:10px">
-            	    <input type="submit" value="update">
-            	</div>
-            	<div style="float:right;">
-            		<label style="margin:0 5px">in</label>
-            		<select id="costFormat" name="costFormat">
-            		    <option value="percent" <?php echo (Webgrind_Config::$defaultCostformat=='percent') ? 'selected' : ''?>>percent</option>
-            		    <option value="msec" <?php echo (Webgrind_Config::$defaultCostformat=='msec') ? 'selected' : ''?>>milliseconds</option>
-            		    <option value="usec" <?php echo (Webgrind_Config::$defaultCostformat=='usec') ? 'selected' : ''?>>microseconds</option>
-            		</select>
-            	</div>
-            	<div style="float:right;">
-            		<label style="margin:0 5px">of</label>
-            		<select id="dataFile" name="dataFile" style="width:200px">
-            			<option value="0">Auto (newest)</option>
-            			<?php foreach(Webgrind_FileHandler::getInstance()->getTraceList() as $trace):?>
+                <div style="float:right;margin-left:10px">
+                    <input type="submit" value="update"/>
+                    <input type="button" onclick="deleteProfiles();return false;" value="clear profiles"/>
+                </div>
+                <div style="float:right;">
+                    <label style="margin:0 5px">in</label>
+                    <select id="costFormat" name="costFormat">
+                        <option value="percent" <?php echo (Webgrind_Config::$defaultCostformat=='percent') ? 'selected' : ''?>>percent</option>
+                        <option value="msec" <?php echo (Webgrind_Config::$defaultCostformat=='msec') ? 'selected' : ''?>>milliseconds</option>
+                        <option value="usec" <?php echo (Webgrind_Config::$defaultCostformat=='usec') ? 'selected' : ''?>>microseconds</option>
+                    </select>
+                </div>
+                <div style="float:right;">
+                    <label style="margin:0 5px">of</label>
+                    <select id="dataFile" name="dataFile" style="width:200px">
+                        <option value="0">Auto (newest)</option>
+                        <?php foreach(Webgrind_FileHandler::getInstance()->getTraceList() as $trace):?>
                             <!-- <option value="<?php echo $trace['filename']?>"><?php echo $trace['invokeUrl']?> (<?php echo $trace['filename']?>) [<?php echo $trace['filesize']?>]</option> -->
                             <option value="<?php echo $trace['filename']?>"><?php echo str_replace(array('%i','%f','%s','%m'),array($trace['invokeUrl'],$trace['filename'],$trace['filesize'],$trace['mtime']),Webgrind_Config::$traceFileListFormat); ?></option>
-            			<?php endforeach;?>
-            		</select>
-        			<img class="list_reload" src="img/reload.png" onclick="reloadFilelist()">
-            	</div>
-            	<div style="float:right">
-            		<label style="margin:0 5px">Show</label>
-            		<select id="showFraction" name="showFraction">
-            			<?php for($i=100; $i>0; $i-=10):?>
-            			<option value="<?php echo $i/100?>" <?php if ($i==Webgrind_Config::$defaultFunctionPercentage):?>selected="selected"<?php endif;?>><?php echo $i?>%</option>
-            			<?php endfor;?>
-            		</select>
-            	</div>
-            	<div style="clear:both;"></div>    	
-            	<div style="margin:0 70px">
-            	    <input type="checkbox" name="hideInternals" value="1" <?php echo (Webgrind_Config::$defaultHideInternalFunctions==1) ? 'checked' : ''?> id="hideInternals">
-            	    <label for="hideInternals">Hide PHP functions</label>
-            	</div>
+                        <?php endforeach;?>
+                    </select>
+                    <img class="list_reload" src="img/reload.png" onclick="reloadFilelist()">
+                </div>
+                <div style="float:right">
+                    <label style="margin:0 5px">Show</label>
+                    <select id="showFraction" name="showFraction">
+                        <?php for($i=100; $i>0; $i-=10):?>
+                        <option value="<?php echo $i/100?>" <?php if ($i==Webgrind_Config::$defaultFunctionPercentage):?>selected="selected"<?php endif;?>><?php echo $i?>%</option>
+                        <?php endfor;?>
+                    </select>
+                </div>
+                <div style="clear:both;"></div>     
+                <div style="margin:0 70px">
+                    <input type="checkbox" name="hideInternals" value="1" <?php echo (Webgrind_Config::$defaultHideInternalFunctions==1) ? 'checked' : ''?> id="hideInternals">
+                    <label for="hideInternals">Hide PHP functions</label>
+                </div>
             </form>
         </div>
         
@@ -334,37 +364,37 @@
     <div id="main">
         
         <div id="trace_view">
-        	<div style="float:left;">
-        	    <h2 id="invoke_url"></h2>
-        	    <span id="data_file"></span> @ <span id="mtime"></span>
-        	</div>
-        	<div style="float:right;">
-        	    <div id="breakdown" style="margin-bottom:5px;width:320px;height:20px"></div>
-        	    <span id="invocation_sum"></span> different functions called in <span id="runtime_sum"></span> milliseconds (<span id="runs"></span> runs, <span id="shown_sum"></span> shown)
-				<div><input type="button" name="graph" value="Show Call Graph" onclick="showCallGraph()"></div>
-        	</div>
-        	<div style="clear:both"></div>
-        	Filter: <input type="text" style="width:150px" id="callfilter"> (regex too)
-        	<table class="tablesorter" id="function_table" cellspacing="0">
-        		<thead>
-        		    <tr>
-        		        <th> </th>
-        		        <th><span>Function</span></th>
-        		        <th> </th>
-        		        <th><span>Invocation Count</span></th>
-        		        <th><span>Total Self Cost</span></th>
-        		        <th><span>Total Inclusive Cost</span></th>
-        		    </tr>
-        		</thead>
-        		<tbody>
-        		</tbody>
-        	</table>
+            <div style="float:left;">
+                <h2 id="invoke_url"></h2>
+                <span id="data_file"></span> @ <span id="mtime"></span>
+            </div>
+            <div style="float:right;">
+                <div id="breakdown" style="margin-bottom:5px;width:320px;height:20px"></div>
+                <span id="invocation_sum"></span> different functions called in <span id="runtime_sum"></span> milliseconds (<span id="runs"></span> runs, <span id="shown_sum"></span> shown)
+                <div><input type="button" name="graph" value="Show Call Graph" onclick="showCallGraph()"></div>
+            </div>
+            <div style="clear:both"></div>
+            Filter: <input type="text" style="width:150px" id="callfilter"> (regex too)
+            <table class="tablesorter" id="function_table" cellspacing="0">
+                <thead>
+                    <tr>
+                        <th> </th>
+                        <th><span>Function</span></th>
+                        <th> </th>
+                        <th><span>Invocation Count</span></th>
+                        <th><span>Total Self Cost</span></th>
+                        <th><span>Total Inclusive Cost</span></th>
+                    </tr>
+                </thead>
+                <tbody>
+                </tbody>
+            </table>
         </div>
         <h2 id="hello_message"><?php echo $welcome?></h2>
         <div id="footer">
             <?php if(Webgrind_Config::$checkVersion):?>
-        	<div id="version_info">&nbsp;</div>
-        	<?php endif?>
+            <div id="version_info">&nbsp;</div>
+            <?php endif?>
             Copyright © 2008-2011 Jacob Oettinger &amp; Joakim Nygård. <a href="http://github.com/jokkedk/webgrind/">webgrind homepage</a>
         </div>
     </div>


### PR DESCRIPTION
Got a few changes here

When you have an auto_prepend_file you end up with 2 {main} stacks however the current implementation only allows for one {main} stack. This will fix that

There seemed to be a lot of functions that would not show, so I removed the check against 'remaining cost' so that all functions will display.

Added a button to delete all profiles