### PR TITLE
Automatically determine python and dot paths

### DIFF
--- a/config.php
+++ b/config.php
@@ -33,12 +33,12 @@ class Webgrind_Config extends Webgrind_MasterConfig {
 	/**
 	* Path to python executable
 	*/ 
-	static $pythonExecutable = '/usr/bin/python';
+	static $pythonExecutable = system('which python');
 	
 	/**
 	* Path to graphviz dot executable
 	*/	
-	static $dotExecutable = '/usr/local/bin/dot';
+	static $dotExecutable = system('which dot');
 		
 	/**
 	* sprintf compatible format for generating links to source files. 


### PR DESCRIPTION
This simple fix finds python and dot on the current system path, so dot in /usr/bin is found automatically.