### PR TITLE
Make the installation section an actual list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Mailing list is available through the [webgrind google group](http://groups.goog
 
 Installation
 ------------
-  # Download webgrind
-  # Unzip package to favourite path accessible by webserver.
-  # Load webgrind in browser and start profiling
+  1. Download webgrind
+  2. Unzip package to favourite path accessible by webserver.
+  3. Load webgrind in browser and start profiling
 
 See the [Installation page on Google Code](http://code.google.com/p/webgrind/wiki/Installation) for more
 


### PR DESCRIPTION
The installation steps ends up on the same line since the #'s are not interpreted as list items. Changing to numbers makes it an ordered list according to GitHub Flavored Markdown.
