### PR TITLE
added quotes around file paths

### DIFF
--- a/index.php
+++ b/index.php
@@ -148,7 +148,7 @@ try {
             header("Content-Type: image/png");
             $filename = Webgrind_Config::storageDir().$dataFile.'-'.$showFraction.Webgrind_Config::$preprocessedSuffix.'.png';
 		    if (!file_exists($filename)) {
-				shell_exec(Webgrind_Config::$pythonExecutable.' library/gprof2dot.py -n '.$showFraction.' -f callgrind '.Webgrind_Config::xdebugOutputDir().''.$dataFile.' | '.Webgrind_Config::$dotExecutable.' -Tpng -o ' . $filename);
+				shell_exec(Webgrind_Config::$pythonExecutable.' library/gprof2dot.py -n '.$showFraction.' -f callgrind "'.Webgrind_Config::xdebugOutputDir().''.$dataFile.'" | '.Webgrind_Config::$dotExecutable.' -Tpng -o "' . $filename . '"');
 			}
 			readfile($filename);
 		break;


### PR DESCRIPTION
`shell_exec` was failing on paths containing spaces
