### PR TITLE
Fix #62 Support for XDebug 2.3 function/file name compression in calls/called by and top level names.

### DIFF
--- a/library/Preprocessor.php
+++ b/library/Preprocessor.php
@@ -62,10 +62,10 @@ class Webgrind_Preprocessor
 			if(substr($line,0,3)==='fl='){
 				// Found invocation of function. Read functionname
 				list($function) = fscanf($in,"fn=%[^\n\r]s");
-            $function = self::getCompressedName($function, 0);
+				$function = self::getCompressedName($function, false);
 				if(!isset($functions[$function])){
 					$functions[$function] = array(
-                        'filename'              => self::getCompressedName(substr(trim($line),3), 1),
+                        'filename'              => self::getCompressedName(substr(trim($line),3), true),
                         'invocationCount'       => 0,
                         'nr'                    => $nextFuncNr++,
                         'count'                 => 0,
@@ -90,7 +90,7 @@ class Webgrind_Preprocessor
 			} else if(substr($line,0,4)==='cfn=') {
 				
 				// Found call to function. ($function should contain function call originates from)
-				$calledFunctionName = self::getCompressedName(substr(trim($line),4), 0);
+				$calledFunctionName = self::getCompressedName(substr(trim($line),4), false);
 				// Skip call line
 				fgets($in);
 				// Cost line
@@ -159,22 +159,24 @@ class Webgrind_Preprocessor
 		
 	}
 
-   protected static function getCompressedName($name, $type=0)
-   {
-      global $compressedNames;
-      if(preg_match("/\((\d+)\)(.+)?/", $name, $matches))
-      {
-         $functionIndex = $matches[1];
-         if(isset($compressedNames[$type][$functionIndex]) && isset($matches[2]) == false)
-         {
-            $name = $compressedNames[$type][$functionIndex];
-         }
-         else
-         {
-            $name = trim($matches[2]);
-            $compressedNames[$type][$functionIndex] = $name;
-         }
-      }
-      return $name;
-   }
+	/**
+	 * Extract information from $inFile and store in preprocessed form in $outFile
+	 *
+	 * @param string $name String to parse (either a filename or function name line)
+	 * @param int $isFile True if this is a filename line (since files and functions have their own symbol tables)
+	 * @return void
+	 **/
+	static function getCompressedName($name, $isFile){
+		global $compressedNames;
+		if(preg_match("/\((\d+)\)(.+)?/", $name, $matches)){
+			$functionIndex = $matches[1];
+			if(isset($compressedNames[$isFile][$functionIndex]) && isset($matches[2]) == false){
+				$name = $compressedNames[$isFile][$functionIndex];
+			} else{
+				$name = trim($matches[2]);
+				$compressedNames[$isFile][$functionIndex] = $name;
+			}
+		}
+		return $name;
+	}
 }

--- a/library/Preprocessor.php
+++ b/library/Preprocessor.php
@@ -62,9 +62,10 @@ class Webgrind_Preprocessor
 			if(substr($line,0,3)==='fl='){
 				// Found invocation of function. Read functionname
 				list($function) = fscanf($in,"fn=%[^\n\r]s");
+            $function = self::getCompressedName($function, 0);
 				if(!isset($functions[$function])){
 					$functions[$function] = array(
-                        'filename'              => substr(trim($line),3), 
+                        'filename'              => self::getCompressedName(substr(trim($line),3), 1),
                         'invocationCount'       => 0,
                         'nr'                    => $nextFuncNr++,
                         'count'                 => 0,
@@ -89,7 +90,7 @@ class Webgrind_Preprocessor
 			} else if(substr($line,0,4)==='cfn=') {
 				
 				// Found call to function. ($function should contain function call originates from)
-				$calledFunctionName = substr(trim($line),4);
+				$calledFunctionName = self::getCompressedName(substr(trim($line),4), 0);
 				// Skip call line
 				fgets($in);
 				// Cost line
@@ -157,5 +158,23 @@ class Webgrind_Preprocessor
 		}
 		
 	}
-	
+
+   protected static function getCompressedName($name, $type=0)
+   {
+      global $compressedNames;
+      if(preg_match("/\((\d+)\)(.+)?/", $name, $matches))
+      {
+         $functionIndex = $matches[1];
+         if(isset($compressedNames[$type][$functionIndex]) && isset($matches[2]) == false)
+         {
+            $name = $compressedNames[$type][$functionIndex];
+         }
+         else
+         {
+            $name = trim($matches[2]);
+            $compressedNames[$type][$functionIndex] = $name;
+         }
+      }
+      return $name;
+   }
 }


### PR DESCRIPTION
This is an adaptation of the commit referenced on #62 that moves that fix into the preprocessor and provides correct names in the call tree (not just the top level function). Based on work by MoleDJ at https://github.com/MoleDJ/webgrind/commit/516832571b154f093c512709ccef7c1f7bae9bba