### PR TITLE
Escape Shell Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -148,7 +148,7 @@ try {
             header("Content-Type: image/png");
             $filename = Webgrind_Config::storageDir().$dataFile.'-'.$showFraction.Webgrind_Config::$preprocessedSuffix.'.png';
 		    if (!file_exists($filename)) {
-				shell_exec(Webgrind_Config::$pythonExecutable.' library/gprof2dot.py -n '.$showFraction.' -f callgrind '.Webgrind_Config::xdebugOutputDir().''.$dataFile.' | '.Webgrind_Config::$dotExecutable.' -Tpng -o ' . $filename);
+				shell_exec(Webgrind_Config::$pythonExecutable.' library/gprof2dot.py -n '.$showFraction.' -f callgrind '.Webgrind_Config::xdebugOutputDir().''.escapeshellarg($dataFile).' | '.Webgrind_Config::$dotExecutable.' -Tpng -o ' . escapeshellarg($filename));
 			}
 			readfile($filename);
 		break;


### PR DESCRIPTION
Due to `$dataFile` being read in by `$_GET`, this enables a remote attacker to inject shell commands and run as PHP on the remote server, enabling Remote Code Execution.  `escapeshellarg` will stop the immediate direct injection threat, however additional sanitization should be performed to ensure no inputs can result in overwritten files, etc.