### PR TITLE
Escape dot in regular expression.

### DIFF
--- a/library/FileHandler.php
+++ b/library/FileHandler.php
@@ -50,7 +50,7 @@ class Webgrind_FileHandler{
 	 * @return void string
 	 */	
 	private function getInvokeUrl($file){
-	    if (preg_match('/.webgrind$/', $file)) 
+	    if (preg_match('/\.webgrind$/', $file)) 
 	        return 'Webgrind internal';
 
 		// Grab name of invoked file. 


### PR DESCRIPTION
Without the escape, you'll match any filename that ends with "webgrind", even if the character before the string is not a period.