### PR TITLE
Add documentation on how to run with built-in server and Composer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Installation
   2. Unzip package to favourite path accessible by webserver.
   3. Load webgrind in browser and start profiling
 
+Alternatively, on PHP 5.4+ run the application using the PHP built-in server
+with the command `composer serve` or `php -S 0.0.0.0:8080 index.php` if you
+are not using Composer.
+
 For faster preprocessing under linux, give write access to the `bin` subdirectory
 or execute `make` in the unzipped folder (requires GCC).
 

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
         "issues": "https://github.com/jokkedk/webgrind/issues",
         "wiki": "https://github.com/jokkedk/webgrind/wiki",
         "source": "https://github.com/jokkedk/webgrind"
+    },
+    "scripts": {
+        "serve": "php -S 0.0.0.0:8080 index.php"
     }
 }


### PR DESCRIPTION
Hello,

For quick setup the PHP built-in server works great for this application. This PR adds a Composer script that allows to run the application without a web-server. It also adds documentation on how to do that without Composer.

Thanks,
Rob