### PR TITLE
Mark vendored files to improve repository language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/js/jquery.js linguist-vendored
+/js/jquery.*.js linguist-vendored
+/js/sprintf.js linguist-vendored
+
+/library/gprof2dot.py linguist-vendored


### PR DESCRIPTION
The repository is currently recognized as Python because of the embedded [gprof2dot](https://github.com/jrfonseca/gprof2dot).
This have an effect for example when searching through starred repositories.

Therefore adding rules for [Linguist](https://github.com/github/linguist#readme).