### PR TITLE
Add Windows support for the preprocessor

### DIFF
--- a/Nmakefile
+++ b/Nmakefile
@@ -1,0 +1,21 @@
+CXX = cl.exe
+CFLAGS = /O2 /W3 /MT /GS /Gy /EHsc /Zi /nologo /analyze
+SRCS = library/preprocessor.cpp
+OUT = bin\preprocessor.exe
+
+
+all: $(OUT)
+
+help:
+	@echo "Targets:"
+	@echo "  all     - build preprocessor"
+	@echo "  clean   - clear generated binaries"
+	@echo "  help    - show this message\n"
+
+clean:
+	del "$(OUT)" > nul
+
+$(OUT): $(SRCS)
+	cl.exe $(CFLAGS) $(SRCS) /Fe$(OUT)
+
+.PHONY: all help clean

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Webgrind
 ========
-Webgrind is a [Xdebug](http://www.xdebug.org) profiling web frontend in PHP. It implements a subset of the features of [kcachegrind](http://kcachegrind.sourceforge.net/html/Home.html) and installs in seconds and works on all platforms. For quick'n'dirty optimizations it does the job. Here's a screenshot showing the output from profiling:
+Webgrind is an [Xdebug](http://www.xdebug.org) profiling web frontend in PHP. It implements a subset of the features of [kcachegrind](http://kcachegrind.sourceforge.net/html/Home.html) and installs in seconds and works on all platforms. For quick'n'dirty optimizations it does the job. Here's a screenshot showing the output from profiling:
 
 [![](http://jokke.dk/media/2008-webgrind/webgrind_small.png)](http://jokke.dk/media/2008-webgrind/webgrind_large.png)
 
@@ -24,10 +24,11 @@ Alternatively, on PHP 5.4+ run the application using the PHP built-in server
 with the command `composer serve` or `php -S 0.0.0.0:8080 index.php` if you
 are not using Composer.
 
-For faster preprocessing under linux, give write access to the `bin` subdirectory
-or execute `make` in the unzipped folder (requires GCC).
+For faster preprocessing, give write access to the `bin` subdirectory, or compile manually:
+  * Linux / Mac OS X: execute `make` in the unzipped folder (requires GCC or Clang.)
+  * Windows: execute `nmake -f NMakeFile` in the unzipped folder (requires Visual Studio 2015 or higher.)
 
-See the [Installation Wiki page](https://github.com/jokkedk/webgrind/wiki/Installation) for more
+See the [Installation Wiki page](https://github.com/jokkedk/webgrind/wiki/Installation) for more.
 
 Credits
 -------

--- a/library/Preprocessor.php
+++ b/library/Preprocessor.php
@@ -44,17 +44,17 @@ class Webgrind_Preprocessor
      */
     static function parse($inFile, $outFile)
     {
+        // If possible, use the binary preprocessor
+        if (self::binaryParse($inFile, $outFile)) {
+            return;
+        }
+
         $in = @fopen($inFile, 'rb');
         if (!$in)
             throw new Exception('Could not open '.$inFile.' for reading.');
         $out = @fopen($outFile, 'w+b');
         if (!$out)
             throw new Exception('Could not open '.$outFile.' for writing.');
-
-        // If possible, use the binary preprocessor
-        if (self::binaryParse($inFile, $outFile)) {
-            return;
-        }
 
         $proxyFunctions = array_flip(Webgrind_Config::$proxyFunctions);
         $proxyQueue = array();
@@ -189,6 +189,9 @@ class Webgrind_Preprocessor
         foreach ($functionAddresses as $address) {
             fwrite($out, pack(self::NR_FORMAT, $address));
         }
+
+        fclose($in);
+        fclose($out);
     }
 
     /**
@@ -232,8 +235,8 @@ class Webgrind_Preprocessor
         foreach (Webgrind_Config::$proxyFunctions as $function) {
             $cmd .= ' '.escapeshellarg($function);
         }
-        exec($cmd);
-        return true;
+        exec($cmd, $output, $ret);
+        return $ret == 0;
     }
 
 }

--- a/library/preprocessor.cpp
+++ b/library/preprocessor.cpp
@@ -2,9 +2,14 @@
  * This is ported from Preprocessor.php for performance.
  */
 
-// #include <Winsock2.h>
+#ifndef _WIN32
 #include <arpa/inet.h>
+#else
+#include <Winsock2.h>
+#pragma comment(lib, "ws2_32.lib")
+#endif
 #include <algorithm>
+#include <cctype>
 #include <fstream>
 #include <map>
 #include <queue>


### PR DESCRIPTION
I'd actually been using my own binary for an older version of the format.  Glad to see this as part of the mainline.

This includes automatic compilation as well, although The VS2017 (VSAPPIDDIR) path is not heavily tested.

-[Unknown]