### PR TITLE
Fix PHP Notice "non well formed numeric value"

### DIFF
--- a/library/Reader.php
+++ b/library/Reader.php
@@ -202,6 +202,8 @@ class Webgrind_Reader
             while ($line=$this->readLine()) {
                 $parts = explode(': ',$line);
                 if ($parts[0] == 'summary') {
+                    // According to https://github.com/xdebug/xdebug/commit/926808a6e0204f5835a617caa3581b45f6d82a6c#diff-1a570e993c4d7f2e341ba24905b8b2cdR355
+                    // summary now includes time + memory usage, webgrind only tracks the time from the summary
                     $subParts = explode(' ', $parts[1])
                     $this->headers['runs']++;
                     $this->headers['summary'] += $subParts[0];

--- a/library/Reader.php
+++ b/library/Reader.php
@@ -202,8 +202,9 @@ class Webgrind_Reader
             while ($line=$this->readLine()) {
                 $parts = explode(': ',$line);
                 if ($parts[0] == 'summary') {
+                    $subParts = explode(' ', $parts[1])
                     $this->headers['runs']++;
-                    $this->headers['summary'] += $parts[1];
+                    $this->headers['summary'] += $subParts[0];
                 } else {
                     $this->headers[$parts[0]] = $parts[1];
                 }


### PR DESCRIPTION
php 7.1+ with xdebug configured for `xdebug.force_display_errors=1` causes a notice to be prefixed to the json

This is because the summary line can be formatted like: `summary: 2111346 5360368`

Previous php behaviour would be to extract the `2111346` chunk since it "looks" number-like, which this change replicates. I'm not sure what the second numerical value is for, but didn't want to throw it away via an explicit `(int)$parts[1]` cast