### PR TITLE
Add a working Docker image (#124)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM php:7.4-apache
+WORKDIR /var/www/html
+
+COPY . /var/www/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,18 @@
+FROM php:7.4-apache as builder
+
+COPY . /build
+
+RUN apt-get update \
+    && apt-get install -y build-essential \
+    && cd /build \
+    && make
+
 FROM php:7.4-apache
 WORKDIR /var/www/html
 
+RUN apt-get update \
+    && apt-get install -y graphviz python3 \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY . /var/www/html
+COPY --from=builder /build/bin/preprocessor /var/www/html/bin/preprocessor

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ For faster preprocessing, give write access to the `bin` subdirectory, or compil
 
 See the [Installation Wiki page](https://github.com/jokkedk/webgrind/wiki/Installation) for more.
 
+Use with Docker
+---------------
+
+Instead of uploading webgrind to a web server or starting a local one, you can use the official Docker image to 
+quickly inspect existing xDebug profiling files. To use the Docker image, run the following command with
+`/path/to/xdebug/files` replaced by the actual path of your profiling files.
+
+```
+docker run -v /path/to/xdebug/files:/tmp -p 80:80 jokkedk/webgrind:latest
+```
+
+Now open `http://localhost` in your browser. After using webgrind you can stop the Docker container by pressing 
+`CTRL / Strg` + `C`.
+
 Credits
 -------
 Webgrind is written by [Joakim Nygård](http://jokke.dk) and [Jacob Oettinger](http://oettinger.dk). It would not have been possible without the great tool that Xdebug is thanks to [Derick Rethans](http://www.derickrethans.nl).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+
+  webgrind:
+    image: jokkedk/webgrind:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:80:80"
+    volumes:
+      # Replace '/path/to/xdebug/files' with the actual path of the xDebug profiling files
+      - /path/to/xdebug/files:/tmp


### PR DESCRIPTION
This pull requests adds two new files:

- Dockerfile
- docker-compose.yml

The Dockerfile uses the existing PHP 7.4 image with Apache preinstalled and pushes the webgrind files into it. Nothing more is needed at the moment. I updated the Readme with usage instructions.
The docker-compose file can be used to run webgrind permanently as a service.

⚠️ Before merging this pull request, please make sure there is a working Docker Hub repository which is configured to automatically build Docker images of the master branch, using the Dockerfile as a base. At the moment I assume that the Docker repository is available as jokkedk/webgrind. If this is not possible please comment and I will change the files accordingly.
If you need help with this please feel free to contact me privately.