### PR TITLE
Opt-in to file content disclosure

### DIFF
--- a/config.php
+++ b/config.php
@@ -56,6 +56,19 @@ class Webgrind_Config extends Webgrind_MasterConfig {
     //static $fileUrlFormat = 'file://%1$s'; // ?
 
     /**
+     * enable viewing of server files.
+     * add whatever logic necessary to determine whether a visitor can access a particular file.
+     */
+    //static function exposeServerFile($file) {
+    //    # restore previous behaviour of allowing viewing any accessible files, including those outside the docroot
+    //    return true;
+    //    # limit to web root
+    //    return isset($_SERVER['DOCUMENT_ROOT'])
+    //        && ($file = realpath($file))
+    //        && preg_match('#^' . preg_quote($_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR, '#') . '#', $file);
+    //}
+
+    /**
      * format of the trace drop down list
      * default is: invokeurl (tracefile_name) [tracefile_size]
      * the following options will be replaced:

--- a/index.php
+++ b/index.php
@@ -11,9 +11,13 @@ if (PHP_SAPI == 'cli-server') {
     }
 }
 
-class Webgrind_MasterConfig
+abstract class Webgrind_MasterConfig
 {
     static $webgrindVersion = '1.7';
+
+    static function exposeServerFile($file) {
+        return false;
+    }
 }
 
 require './config.php';
@@ -129,7 +133,9 @@ try {
         case 'fileviewer':
             $file = get('file');
 
-            if ($file && $file!='') {
+            if (!Webgrind_MasterConfig::exposeServerFile($file)) {
+                $message = 'Edit your Webgrind config.php to allow viewing of server files.';
+            } else if ($file != '') {
                 $message = '';
                 if (!file_exists($file)) {
                     $message = $file.' does not exist.';

--- a/index.php
+++ b/index.php
@@ -133,19 +133,18 @@ try {
         case 'fileviewer':
             $file = get('file');
 
-            if (!Webgrind_Config::exposeServerFile($file)) {
-                $message = 'Edit your Webgrind config.php to allow viewing of server files.';
-            } else if ($file != '') {
-                $message = '';
-                if (!file_exists($file)) {
-                    $message = $file.' does not exist.';
-                } else if (!is_readable($file)) {
-                    $message = $file.' is not readable.';
-                } else if (is_dir($file)) {
-                    $message = $file.' is a directory.';
-                }
-            } else {
+            if ($file == '') {
                 $message = 'No file to view';
+            } else if (!Webgrind_Config::exposeServerFile($file)) {
+                $message = 'The config does not allow you to view this file.';
+            } else if (!file_exists($file)) {
+                $message = $file.' does not exist.';
+            } else if (!is_readable($file)) {
+                $message = $file.' is not readable.';
+            } else if (is_dir($file)) {
+                $message = $file.' is a directory.';
+            } else {
+                $message = '';
             }
             require 'templates/fileviewer.phtml';
         break;

--- a/index.php
+++ b/index.php
@@ -133,7 +133,7 @@ try {
         case 'fileviewer':
             $file = get('file');
 
-            if (!Webgrind_MasterConfig::exposeServerFile($file)) {
+            if (!Webgrind_Config::exposeServerFile($file)) {
                 $message = 'Edit your Webgrind config.php to allow viewing of server files.';
             } else if ($file != '') {
                 $message = '';


### PR DESCRIPTION
Regardless of this tool's intent for development use only, providing a backdoor to view the contents of **any accessible file** by default is a security flaw. It happily displays any contents of sensitive files that would otherwise be blocked by web server configuration, or normally produce no output. Even the [documentation of the function employed](https://www.php.net/manual/en/function.highlight-file.php) warns against inadvertent disclosure.

Any argument that this is okay because it is for local testing ignores that fact that developers often work on remote machines, even if on a private network, and may not want to expose all files to everyone and everything on that network. They may not even realise that's what they're doing by using this tool. The feature is great, it being insecure is not.

Relevant bugs: #65 #79 #112 #115 