### PR TITLE
Fix Xdebug 3.0 incompatibility.

### DIFF
--- a/config.php
+++ b/config.php
@@ -135,7 +135,7 @@ class Webgrind_Config extends Webgrind_MasterConfig {
      * Directory to search for trace files
      */
     static function xdebugOutputDir() {
-        $dir = ini_get('xdebug.profiler_output_dir');
+        $dir = ini_get('xdebug.output_dir');
         if ($dir=='') // Ini value not defined
             return realpath(Webgrind_Config::$profilerDir).'/';
         return realpath($dir).'/';


### PR DESCRIPTION
Xdebug 3 has deprecated profiler_output_dir in favor of output_dir. I updated the config.php file to reflect this change as it is breaking webgrind's ability to find any files to read currently.