### PR TITLE
Use array() vs [] to maintain PHP5 compatibility

### DIFF
--- a/library/Reader.php
+++ b/library/Reader.php
@@ -90,7 +90,7 @@ class Webgrind_Reader
             throw new Exception('Datafile not correct version. Found '.$version.' expected '.self::FILE_FORMAT_VERSION);
         $this->functionPos = $this->read($functionCount);
         if (!is_array($this->functionPos))
-            $this->functionPos = [$this->functionPos];
+            $this->functionPos = array($this->functionPos);
     }
 
     /**


### PR DESCRIPTION
Using `array()` vs `[]` here helps maintain PHP5 compatibility (and is also consistent with what is used in the project already).