### PR TITLE
Update kcachegrind link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Webgrind
 ========
-Webgrind is an [Xdebug](http://www.xdebug.org) profiling web frontend in PHP. It implements a subset of the features of [kcachegrind](http://kcachegrind.sourceforge.net/html/Home.html) and installs in seconds and works on all platforms. For quick'n'dirty optimizations it does the job. Here's a screenshot showing the output from profiling:
+Webgrind is an [Xdebug](http://www.xdebug.org) profiling web frontend in PHP. It implements a subset of the features of [kcachegrind](https://kcachegrind.github.io/) and installs in seconds and works on all platforms. For quick'n'dirty optimizations it does the job. Here's a screenshot showing the output from profiling:
 
 [![](http://jokke.dk/media/2008-webgrind/webgrind_small.png)](http://jokke.dk/media/2008-webgrind/webgrind_large.png)
 


### PR DESCRIPTION
The old URL indicates the site is no longer canonical,
with development having moved to GitHub.

Fixes https://github.com/jokkedk/webgrind/issues/114.