### PR TITLE
Add download link to filename once it's loaded 

### DIFF
--- a/index.php
+++ b/index.php
@@ -207,11 +207,11 @@ try {
                 exit;
             }
 
-            header("Cache-Control: public");
-            header("Content-Description: File Transfer");
-            header("Content-Disposition: attachment; filename=".get('file'));
-            header("Content-Type: text/plain");
-            header("Content-Transfer-Encoding: binary");
+            header('Cache-Control: public');
+            header('Content-Description: File Transfer');
+            header('Content-Disposition: attachment; filename='.get('file'));
+            header('Content-Type: text/plain');
+            header('Content-Transfer-Encoding: binary');
 
             readfile($file);
         break;

--- a/index.php
+++ b/index.php
@@ -191,7 +191,7 @@ try {
         case 'download_link':
             $file = Webgrind_Config::exposeServerFile(get('file'));
 
-            if (!$file) {
+            if ($file === false) {
                 http_response_code(404);
                 sendJson(array('error' => 'No file found or access denied!'));
                 exit;
@@ -204,7 +204,7 @@ try {
         case 'download_file':
             $file = Webgrind_Config::exposeServerFile(get('file'));
 
-            if (!$file) {
+            if ($file === false) {
                 exit;
             }
 

--- a/index.php
+++ b/index.php
@@ -189,7 +189,7 @@ try {
         break;
 
         case 'download_link':
-            $file = Webgrind_Config::exposeServerFile(get('file'));
+            $file = Webgrind_Config::exposeServerFile(Webgrind_Config::xdebugOutputDir().get('file'));
 
             if (empty($file)) {
                 sendJson(array('error' => 'No file found or access denied!'));
@@ -201,7 +201,7 @@ try {
         break;
 
         case 'download_file':
-            $file = Webgrind_Config::exposeServerFile(get('file'));
+            $file = Webgrind_Config::exposeServerFile(Webgrind_Config::xdebugOutputDir().get('file'));
 
             if (empty($file)) {
                 exit;

--- a/index.php
+++ b/index.php
@@ -197,7 +197,7 @@ try {
             }
 
             $params = array('op' => 'download_file', 'file' => get('file'));
-            sendJson(array('done' => "?".http_build_query($params)));
+            sendJson(array('done' => '?'.http_build_query($params)));
         break;
 
         case 'download_file':

--- a/index.php
+++ b/index.php
@@ -192,7 +192,6 @@ try {
             $file = Webgrind_Config::exposeServerFile(get('file'));
 
             if ($file === false) {
-                http_response_code(404);
                 sendJson(array('error' => 'No file found or access denied!'));
                 exit;
             }

--- a/index.php
+++ b/index.php
@@ -188,6 +188,22 @@ try {
             }
         break;
 
+        case 'download_file':
+            $file = Webgrind_Config::xdebugOutputDir().get('file');
+
+            if (!$file || !is_file($file) || !is_readable($file)) {
+                break;
+            }
+
+            header("Cache-Control: public");
+            header("Content-Description: File Transfer");
+            header("Content-Disposition: attachment; filename=".get('file'));
+            header("Content-Type: text/plain");
+            header("Content-Transfer-Encoding: binary");
+
+            readfile($file);
+        break;
+
         case 'clear_files':
             $files = Webgrind_FileHandler::getInstance()->getTraceList();
             if (!$files) {

--- a/index.php
+++ b/index.php
@@ -188,11 +188,23 @@ try {
             }
         break;
 
-        case 'download_file':
-            $file = Webgrind_Config::xdebugOutputDir().get('file');
+        case 'download_link':
+            $file = Webgrind_Config::exposeServerFile(get('file'));
 
-            if (!$file || !is_file($file) || !is_readable($file)) {
-                break;
+            if (!$file) {
+                sendJson(array('error' => 'No file found or access denied!'));
+                exit;
+            }
+
+            $params = array('op' => 'download_file', 'file' => get('file'));
+            sendJson(array('done' => "?".http_build_query($params)));
+        break;
+
+        case 'download_file':
+            $file = Webgrind_Config::exposeServerFile(get('file'));
+
+            if (!$file) {
+                exit;
             }
 
             header("Cache-Control: public");

--- a/index.php
+++ b/index.php
@@ -192,6 +192,7 @@ try {
             $file = Webgrind_Config::exposeServerFile(get('file'));
 
             if (!$file) {
+                http_response_code(404);
                 sendJson(array('error' => 'No file found or access denied!'));
                 exit;
             }

--- a/index.php
+++ b/index.php
@@ -191,7 +191,7 @@ try {
         case 'download_link':
             $file = Webgrind_Config::exposeServerFile(get('file'));
 
-            if ($file === false) {
+            if (empty($file)) {
                 sendJson(array('error' => 'No file found or access denied!'));
                 exit;
             }
@@ -203,7 +203,7 @@ try {
         case 'download_file':
             $file = Webgrind_Config::exposeServerFile(get('file'));
 
-            if ($file === false) {
+            if (empty($file)) {
                 exit;
             }
 

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -43,7 +43,6 @@
 						$("#function_table tbody").append(functionTableRow(data.functions[i], data.linkToFunctionLine));
 					}
 					currentDataFile = data.dataFile;
-					$("#download_link").attr("href", "index.php?op=download_file&file="+data.dataFile);
 					$("#data_file").html(data.dataFile);
 					$("#invoke_url").html(data.invokeUrl);
 					$(document).attr('title', 'webgrind of '+data.invokeUrl);
@@ -95,6 +94,21 @@
 			delete vars.costFormat;
 			delete vars.hideInternals;
 			window.open('index.php?' + $.param(vars));
+		}
+
+		function downloadFile() {
+			$.getJSON("index.php",
+				{'op':'download_link','file':currentDataFile},
+				function(data){
+					if (data.error) {
+						$("#hello_message").html(data.error);
+						$("#hello_message").show();
+						return;
+					}
+
+					window.location = data.done;
+				}
+			);
 		}
 
 		function reloadFilelist() {
@@ -394,7 +408,7 @@
 		<div id="trace_view">
 			<div style="float:left;">
 				<h2 id="invoke_url"></h2>
-				<a id="download_link">
+				<a id="download_link" onclick="downloadFile()">
 					<span id="data_file"></span> @ <span id="mtime"></span>
 				</a>
 			</div>

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -43,6 +43,7 @@
 						$("#function_table tbody").append(functionTableRow(data.functions[i], data.linkToFunctionLine));
 					}
 					currentDataFile = data.dataFile;
+					$("#download_link").attr("href", "index.php?op=download_file&file="+data.dataFile);
 					$("#data_file").html(data.dataFile);
 					$("#invoke_url").html(data.invokeUrl);
 					$(document).attr('title', 'webgrind of '+data.invokeUrl);
@@ -393,7 +394,9 @@
 		<div id="trace_view">
 			<div style="float:left;">
 				<h2 id="invoke_url"></h2>
-				<span id="data_file"></span> @ <span id="mtime"></span>
+				<a id="download_link">
+					<span id="data_file"></span> @ <span id="mtime"></span>
+				</a>
 			</div>
 			<div style="float:right;">
 				<div id="breakdown" style="margin-bottom:5px;width:320px;height:20px"></div>

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -99,7 +99,7 @@
 		function downloadFile() {
 			$.getJSON("index.php",
 				{'op':'download_link','file':currentDataFile},
-				function(data){
+				function(data) {
 					if (data.error) {
 						$("#hello_message").html(data.error);
 						$("#hello_message").show();

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -97,12 +97,12 @@
 		}
 
 		function downloadFile() {
-			$.getJSON("index.php",
-				{'op':'download_link','file':currentDataFile},
+			$.getJSON('index.php',
+				{'op': 'download_link', 'file': currentDataFile},
 				function(data) {
 					if (data.error) {
-						$("#hello_message").html(data.error);
-						$("#hello_message").show();
+						$('#hello_message').html(data.error);
+						$('#hello_message').show();
 						return;
 					}
 


### PR DESCRIPTION
I needed a download link for my workflow, so I can skip copying files over ssh or ftp. I can quickly glance over the data in webgrind and save it to local machine for offline inspection with QCacheGrind for example.

I thought that maybe this is a feature worth implementing to the base project so that's why I opened this pull request.
Please let me know if there is something worth improving in this pull request, this is just quickly hacked together.