### PR TITLE
Fix recursive functions have higher inclusive cost than main

### DIFF
--- a/library/Preprocessor.php
+++ b/library/Preprocessor.php
@@ -135,7 +135,9 @@ class Webgrind_Preprocessor
                     $cost = $data['cost'];
                 }
 
-                $functions[$index]['summedInclusiveCost'] += $cost;
+                if ($index !== $calledIndex) {
+                    $functions[$index]['summedInclusiveCost'] += $cost;
+                }
 
                 $key = $index.$lnr;
                 if (!isset($functions[$calledIndex]['calledFromInformation'][$key])) {

--- a/library/preprocessor.cpp
+++ b/library/preprocessor.cpp
@@ -212,7 +212,9 @@ public:
                     pqItr->second.pop();
                 }
 
-                functions[funcIndex].summedInclusiveCost += cost;
+                if (funcIndex != calledIndex) {
+                    functions[funcIndex].summedInclusiveCost += cost;
+                }
 
                 CallData& calledFromData = functions[calledIndex].getCalledFromData(funcIndex, lnr);
 


### PR DESCRIPTION
Fixes the example givein in #33 without trying detect cycles. The costs of a calling function are reported as inclusive costs. When recursion happens, we don't want to add the inclusive cost of the called function to the calling function as they represent the same cost. This prevents inflating the inclusive cost of recursive functions, which should leave `{main}` with the highest inclusive cost.