### PR TITLE
Restore image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Webgrind
 ========
 Webgrind is an [Xdebug](http://www.xdebug.org) profiling web frontend in PHP. It implements a subset of the features of [kcachegrind](https://kcachegrind.github.io/) and installs in seconds and works on all platforms. For quick'n'dirty optimizations it does the job. Here's a screenshot showing the output from profiling:
 
-[![](http://jokke.dk/media/2008-webgrind/webgrind_small.png)](http://jokke.dk/media/2008-webgrind/webgrind_large.png)
+<a href="https://jokkedk.github.io/webgrind/img/webgrind_2008_large.png"><img src="https://jokkedk.github.io/webgrind/img/webgrind_2008_large.png" height="384"></a>
 
 Features
 --------


### PR DESCRIPTION
The original URL became a 404. You might have the original file and be able to restore it at that or another address.

But, I figured, why not add it to the repository. While at it, made it render a bit sharper than before by using the "large" image at a small scale, thus rendering at 2x Hi-DPI, whereas previously it looked more low-res than it was.

The source of the image for this commit was <http://web.archive.org/web/20160305213301/http://jokke.dk/media/2008-webgrind/webgrind_large.png>, and through OxiPNG (lossless) via ImageOptim.