### PR TITLE
Don't assume that profiles for index.php are from webgrind itself

### DIFF
--- a/config.php
+++ b/config.php
@@ -10,7 +10,6 @@ class Webgrind_Config extends Webgrind_MasterConfig {
      * Automatically check if a newer version of webgrind is available for download
      */
     static $checkVersion = true;
-    static $hideWebgrindProfiles = true;
 
     /**
      * Writable dir for information storage.

--- a/library/FileHandler.php
+++ b/library/FileHandler.php
@@ -96,8 +96,6 @@ class Webgrind_FileHandler
                 continue;
 
             $invokeUrl = rtrim($this->getInvokeUrl($absoluteFilename));
-            if (Webgrind_Config::$hideWebgrindProfiles && $invokeUrl == dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'index.php')
-                continue;
 
             $files[$file] = array('absoluteFilename' => $absoluteFilename,
                                   'mtime' => filemtime($absoluteFilename),


### PR DESCRIPTION
Fixes #130.

- Webgrind is a generic tool to display Xdebug profiling results. It works by parsing all `/tmp/cachegrind.out*` files.
- It currently assumes that all profiling results for `index.php` are from Webgrind itself. That is a generic assumption and doesn't apply in any of the Docker use-cases where the Webgrind container is attached to the `/tmp` directory of other PHP containers.

Solutions:

- Default to showing all profiling results.
- Alternative: offer an environment variable or some other configuration option to adjust this particular behaviour.