### PR TITLE
Use the DOCKER:ENABLE flag to enable profiling results for index.php

### DIFF
--- a/library/FileHandler.php
+++ b/library/FileHandler.php
@@ -23,6 +23,9 @@ class Webgrind_FileHandler
     }
 
     private function __construct() {
+        // Show profiles for index.php files if running inside the Docker image
+        //Webgrind_Config::$hideWebgrindProfiles = false; /** DOCKER:ENABLE **/
+
         // Get list of files matching the defined format
         $files = $this->getFiles(Webgrind_Config::xdebugOutputFormat(), Webgrind_Config::xdebugOutputDir());
 


### PR DESCRIPTION
Fixes #130.

An alternative approach to #147.