### PR TITLE
Update Docker CI to include version tags

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,4 +32,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: jokkedk/webgrind:latest,${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,6 +11,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            jokkedk/webgrind
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=semver,pattern={{version}}
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -21,4 +32,4 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: jokkedk/webgrind:latest
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
As an extension of the CI job created in #150 this should add versioned image tags to the Dockerhub release.