### PR TITLE
added support for directories in xdebug.profiler_output_name

### DIFF
--- a/config.php
+++ b/config.php
@@ -128,7 +128,7 @@ class Webgrind_Config extends Webgrind_MasterConfig {
         if ($outputName=='') // Ini value not defined
             $outputName = '/^cachegrind\.out\..+$/';
         else
-            $outputName = '/^'.preg_replace('/(%[^%])+/', '.+', $outputName).'$/';
+            $outputName = '/^'.preg_replace('/(%[^%])+/', '.+', str_replace('/', '\/', $outputName)).'$/';
         return $outputName;
     }
 


### PR DESCRIPTION
`xdebug.profiler_output_name` supports directories, e.g. it's possible to specify it like
```
xdebug.profiler_output_name=profiling/%H/%R_%u
```
This pull request adds support for such a nested layout