### PR TITLE
Feature proposal: have local config to avoid loosing it on update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+/config.local.php

--- a/index.php
+++ b/index.php
@@ -16,7 +16,12 @@ class Webgrind_MasterConfig
     static $webgrindVersion = '1.9.3';
 }
 
-require './config.php';
+// Local config?
+if (file_exists('./config.local.php')) {
+	require './config.local.php';
+} else {
+	require './config.php';
+}
 require './library/FileHandler.php';
 
 // TODO: Errorhandling:


### PR DESCRIPTION
Here is a feature proposal to address a common problem: when we extract a ZIP file of a newer version of the project onto our current source files, any locally defined configurations are lost because config.php is overwritten.

I propose addressing this issue by introducing the option to have a local configuration file, which would be read if present, instead of the standard file. This approach is similar to the way configuration files are handled in `/etc/xx/conf.d` on Linux systems.